### PR TITLE
Update Jeep Wrangler generations: Add Wikipedia reference and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,57 +2,6 @@
 
 This repository contains signal set configurations for the Jeep Wrangler, organized by model year and version. The files are structured to allow for easy differentiation between generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Jeep Wrangler.
 
-## Generations
-
-The Jeep Wrangler has evolved through four generations since 1987, continuing the legacy of the original Jeep CJ series:
-
-- **First Generation YJ (1987-1995)**: First model to carry the Wrangler name, replacing the CJ series. Notable changes included:
-  - Square headlights (unique to this generation)
-  - Improved handling with redesigned suspension
-  - More comfortable interior with improved ergonomics
-  - Fuel-injected 2.5L four-cylinder or 4.2L inline-six engine
-  - Optional Selec-Trac or Command-Trac 4WD systems
-  - Introduction of the Sahara luxury trim
-  - Anti-lock brakes added in later models
-  - Galvanized steel body panels for improved corrosion resistance
-
-- **Second Generation TJ (1997-2006)**: Return to round headlights and introduction of coil spring suspension. Major features included:
-  - Quadra-coil suspension derived from Grand Cherokee
-  - Reintroduction of the classic round headlights
-  - Updated 2.5L four-cylinder or 4.0L inline-six engine options
-  - Introduction of the Rubicon model (2003) with enhanced off-road capability
-  - Optional Dana 44 axles
-  - Improved NVH and ride quality
-  - Introduction of the Unlimited model (2004) with longer wheelbase
-
-- **Third Generation JK (2007-2018)**: First complete redesign under DaimlerChrysler. Notable for:
-  - Introduction of four-door Unlimited model
-  - 3.8L V6 engine (2007-2011)
-  - Upgraded 3.6L Pentastar V6 (2012-2018)
-  - Modern safety features including stability control and airbags
-  - Enhanced interior comfort and features
-  - Available hard and soft top options
-  - Multiple special editions including Mountain, Arctic, and Dragon editions
-  - Improved aerodynamics while maintaining iconic design
-
-- **Fourth Generation JL (2018-present)**: Current generation featuring modernized design and technology while maintaining traditional capabilities:
-  - Multiple powertrain options:
-    - 3.6L Pentastar V6
-    - 2.0L turbocharged four-cylinder
-    - 3.0L EcoDiesel V6
-    - 4xe plug-in hybrid system
-    - 392 HEMI V8 (Rubicon 392)
-  - Eight-speed automatic or six-speed manual transmission
-  - Advanced safety features including blind-spot monitoring
-  - Modern interior with latest Uconnect systems
-  - Improved aerodynamics and fuel efficiency
-  - Enhanced off-road capability in Rubicon trim
-  - Power-operated Sky One-Touch roof option
-  - Fold-down windshield with improved functionality
-  - Available LED lighting
-  - Advanced driver assistance features
-  - Improved sound insulation and ride comfort
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Jeep_Wrangler"
+
 generations:
   - name: "First Generation (YJ)"
     start_year: 1986


### PR DESCRIPTION
- Added references array to generations.yaml with Wikipedia URL
- Removed duplicate Generations section from README (data now exclusively in YAML)
- Verified generation years match Wikipedia article (YJ: 1986-1995, TJ: 1996-2006, JK: 2007-2018, JL: 2018-present)
- All four generations documented with accurate production dates per Wikipedia
